### PR TITLE
Fix: Correct layout for the list fragment

### DIFF
--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
     <TextView
@@ -48,10 +48,10 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/bottom_guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/button_container"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:context=".ui.dashboard.DashboardFragment">
 
         <androidx.recyclerview.widget.RecyclerView
@@ -62,16 +62,5 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_list" />
     </LinearLayout>
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/bottom_guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout"
-        android:layout_marginTop="56dp"
-        android:layout_marginBottom="56dp"
-        app:layout_constraintGuide_begin="56dp"
-        app:layout_constraintGuide_end="56dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Problem:
The list fragment was not being displayed properly.

Changes:
- Modified `app/src/main/res/layout/fragment_list.xml`:
  - Changed root ConstraintLayout's `layout_height` to `match_parent`.
  - Resolved a circular constraint dependency involving a LinearLayout and a Guideline by removing the Guideline and constraining the LinearLayout to its parent's bottom.
  - This ensures the RecyclerView has a correctly defined space to render its content.

Note:
The fragment's Java/Kotlin code and button click handlers are part of an external library. This change corrects the layout override used by that library fragment. Button functionality (for 'Pick Image' and 'Take Photo') depends on the library correctly finding them by their standard IDs, which are present in this layout.

You will need to manually test to confirm the fix and button functionality due to limitations in the automated build environment.